### PR TITLE
Move to relative contexts (fix recursives)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import { Struct, DTYPE as D } from 'struxt';
 
 var myStruct = new Struct();
 myStruct.add({ name: 'str-length', type: D.UINT16 });
-myStruct.add({ name: 'str', type: D.STR, size: () => myStruct.eval('str-length') });
+myStruct.add({ name: 'str', type: D.STR, size: ctx => ctx.get('str-length') });
 
 var data = myStruct.pack({ 'str-length': 5, 'str': 'hello' });
 
@@ -194,7 +194,7 @@ Dynamic structures. This is what makes struxt special! For some parameters (`gro
 ```ts
 const myStruct = new Struct([
 	{ name: 'datatype', type: DTYPE.UINT8 },
-	{ name: 'data', type: self => self.eval('datatype') },
+	{ name: 'data', type: ctx => ctx.get('datatype') },
 ]);
 
 // As the struct is packing the "datatype" component,

--- a/src/dynstruct.ts
+++ b/src/dynstruct.ts
@@ -212,7 +212,7 @@ export class InternalStruct {
 			// Standard component type
 			if ( part.name !== undefined ) {
 				if (part_group!=null && part_type!=null) throw new TypeXorError(`Component ${part.name} evaluated to both substruct and component. One of type/group must be non-null!`);
-				if (part_group==null && part_type==null) throw new TypeXorError(`Component ${part.name} evaluated to neither substruct or component. One of type/group must be non-null!`);
+				if (part_group==null && part_type==null) continue;
 				part_data = data[part.name];
 			}
 
@@ -287,7 +287,7 @@ export class InternalStruct {
 			// Standard component type
 			if ( part.name !== undefined ) {
 				if (part_group!=null && part_type!=null) throw new TypeXorError(`Part ${part.name} resolved to both substruct and component. One of type/group must be non-null!`);
-				if (part_group==null && part_type==null) throw new TypeXorError(`Part ${part.name} resolved to neither substruct or component. One of type/group must be non-null!`);
+				if (part_group==null && part_type==null) continue;
 			}
 
 			// Magic component type

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,13 @@
-import { Struct, InternalStruct } from './dynstruct.js';
+import { Struct, InternalStruct, StructContext } from './dynstruct.js';
 import { DTYPE } from 'datatype.js';
 
 /** Abstract integer type. */
 export type int = number;
 
 export type SharedStruct = Struct|InternalStruct;
-export type ReturnsInt = (self: Struct) => int;
-export type ReturnsStruct = (self: Struct) => SharedStruct;
-export type ReturnsNull = (self: Struct) => null;
+export type ReturnsInt = (context: StructContext) => int;
+export type ReturnsStruct = (context: StructContext) => SharedStruct;
+export type ReturnsNull = (context: StructContext) => null;
 
 /** Component interface. */
 export type Component =  {


### PR DESCRIPTION
Changelog:
- Remove `Struct.eval()`
- Create `StructContext` class
- Provide evaluators with context objects instead of `this`
- Allow null-null type/group resolutions to skip components